### PR TITLE
Remove admin response fields and events table from support

### DIFF
--- a/client/pages/suportes/SuporteForm.tsx
+++ b/client/pages/suportes/SuporteForm.tsx
@@ -44,7 +44,6 @@ const suporteSchema = z.object({
   titulo: z.string().min(1, "Título é obrigatório"),
   descricao: z.string().min(1, "Descrição é obrigatória"),
   status: z.enum(["Aberto", "Em Andamento", "Resolvido", "Fechado"]).optional(),
-  resposta_admin: z.string().optional().nullable(),
 });
 
 type SuporteFormSchema = z.infer<typeof suporteSchema>;
@@ -85,7 +84,6 @@ export function SuporteForm({
       titulo: "",
       descricao: "",
       status: "Aberto",
-      resposta_admin: "",
     },
   });
 
@@ -114,7 +112,6 @@ export function SuporteForm({
         titulo: suporte.titulo,
         descricao: suporte.descricao,
         status: suporte.status,
-        resposta_admin: suporte.resposta_admin || "",
       });
     } else {
       reset({
@@ -125,7 +122,6 @@ export function SuporteForm({
         titulo: "",
         descricao: "",
         status: "Aberto",
-        resposta_admin: "",
       });
     }
   }, [isOpen, suporte, reset, user?.email]);

--- a/client/pages/suportes/SuportesModule.tsx
+++ b/client/pages/suportes/SuportesModule.tsx
@@ -497,8 +497,42 @@ function SuportesModule() {
                         setExportData(enriched);
                         setShowExport(true);
                       } catch {
-                        setExportData(suportes);
-                        setShowExport(true);
+                        // Fallback: export current page enriched with respostas
+                        try {
+                          const enriched = await Promise.all(
+                            suportes.map(async (s) => {
+                              try {
+                                const r = await makeRequest(
+                                  `/api/suportes/${s.id}/respostas`,
+                                );
+                                const respostas: any[] = r?.data || [];
+                                const respostasStr = respostas
+                                  .map((it) => {
+                                    const dt = new Date(it.data_cadastro).toLocaleString(
+                                      "pt-BR",
+                                      {
+                                        year: "numeric",
+                                        month: "2-digit",
+                                        day: "2-digit",
+                                        hour: "2-digit",
+                                        minute: "2-digit",
+                                      },
+                                    );
+                                    return `${it.nome_usuario} - ${dt}`;
+                                  })
+                                  .join("; ");
+                                return { ...s, respostas: respostasStr };
+                              } catch {
+                                return { ...s, respostas: "" };
+                              }
+                            }),
+                          );
+                          setExportData(enriched);
+                          setShowExport(true);
+                        } catch {
+                          setExportData(suportes);
+                          setShowExport(true);
+                        }
                       }
                     }}
                   >

--- a/client/pages/suportes/SuportesModule.tsx
+++ b/client/pages/suportes/SuportesModule.tsx
@@ -452,7 +452,9 @@ function SuportesModule() {
                           const params = new URLSearchParams({
                             page: String(page),
                             limit: String(limit),
-                            ...(statusTab !== "Todos" ? { status: statusTab } : {}),
+                            ...(statusTab !== "Todos"
+                              ? { status: statusTab }
+                              : {}),
                           });
                           const resp: SuportesListResponse = await makeRequest(
                             `/api/suportes?${params}`,
@@ -474,16 +476,15 @@ function SuportesModule() {
                               const respostas: any[] = r?.data || [];
                               const respostasStr = respostas
                                 .map((it) => {
-                                  const dt = new Date(it.data_cadastro).toLocaleString(
-                                    "pt-BR",
-                                    {
-                                      year: "numeric",
-                                      month: "2-digit",
-                                      day: "2-digit",
-                                      hour: "2-digit",
-                                      minute: "2-digit",
-                                    },
-                                  );
+                                  const dt = new Date(
+                                    it.data_cadastro,
+                                  ).toLocaleString("pt-BR", {
+                                    year: "numeric",
+                                    month: "2-digit",
+                                    day: "2-digit",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                  });
                                   return `${it.nome_usuario} - ${dt}`;
                                 })
                                 .join("; ");
@@ -508,16 +509,15 @@ function SuportesModule() {
                                 const respostas: any[] = r?.data || [];
                                 const respostasStr = respostas
                                   .map((it) => {
-                                    const dt = new Date(it.data_cadastro).toLocaleString(
-                                      "pt-BR",
-                                      {
-                                        year: "numeric",
-                                        month: "2-digit",
-                                        day: "2-digit",
-                                        hour: "2-digit",
-                                        minute: "2-digit",
-                                      },
-                                    );
+                                    const dt = new Date(
+                                      it.data_cadastro,
+                                    ).toLocaleString("pt-BR", {
+                                      year: "numeric",
+                                      month: "2-digit",
+                                      day: "2-digit",
+                                      hour: "2-digit",
+                                      minute: "2-digit",
+                                    });
                                     return `${it.nome_usuario} - ${dt}`;
                                   })
                                   .join("; ");

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -715,8 +715,6 @@ CREATE TABLE IF NOT EXISTS suportes (
   titulo VARCHAR(255) NOT NULL,
   descricao TEXT NOT NULL,
   status VARCHAR(20) NOT NULL DEFAULT 'Aberto' CHECK (status IN ('Aberto','Em Andamento','Resolvido','Fechado')),
-  resposta_admin TEXT,
-  data_resposta_admin TIMESTAMP WITH TIME ZONE,
   data_hora_resolvido TIMESTAMP WITH TIME ZONE,
   data_hora_fechado TIMESTAMP WITH TIME ZONE,
   data_cadastro TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
@@ -728,15 +726,6 @@ CREATE INDEX IF NOT EXISTS idx_suportes_status ON suportes(status);
 CREATE INDEX IF NOT EXISTS idx_suportes_prioridade ON suportes(prioridade);
 CREATE INDEX IF NOT EXISTS idx_suportes_tipo ON suportes(tipo);
 
--- Events table to simulate notifications/email logs
-CREATE TABLE IF NOT EXISTS suportes_eventos (
-  id SERIAL PRIMARY KEY,
-  suporte_id INTEGER NOT NULL REFERENCES suportes(id) ON DELETE CASCADE,
-  tipo_evento VARCHAR(50) NOT NULL,
-  detalhes TEXT,
-  data_cadastro TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
-);
-CREATE INDEX IF NOT EXISTS idx_suportes_eventos_suporte ON suportes_eventos(suporte_id);
 
 -- Respostas do suporte (histórico)
 CREATE TABLE IF NOT EXISTS suportes_respostas (

--- a/server/routes/suportes.ts
+++ b/server/routes/suportes.ts
@@ -159,7 +159,6 @@ export const createSuporte: RequestHandler = async (req, res) => {
       .single();
     if (error) throw error;
 
-
     res.status(201).json({ success: true, data });
   } catch (error: any) {
     if (error?.name === "ZodError") {
@@ -424,7 +423,6 @@ export const addRespostaSuporte: RequestHandler = async (req, res) => {
       await supabase.from("suportes").update(update).eq("id", id);
     }
 
-
     const { data: updated } = await supabase
       .from("suportes")
       .select("*")
@@ -475,7 +473,6 @@ export const resolverSuporte: RequestHandler = async (req, res) => {
       .single();
     if (error) throw error;
 
-
     res.json({ success: true, data });
   } catch (error) {
     console.error("Error resolving suporte:", error);
@@ -514,7 +511,6 @@ export const fecharSuporte: RequestHandler = async (req, res) => {
       .select()
       .single();
     if (error) throw error;
-
 
     res.json({ success: true, data });
   } catch (error) {

--- a/server/routes/suportes.ts
+++ b/server/routes/suportes.ts
@@ -21,7 +21,6 @@ const SuporteCreateSchema = z.object({
   titulo: z.string().min(1),
   descricao: z.string().min(1),
   status: z.enum(["Aberto", "Em Andamento", "Resolvido", "Fechado"]).optional(),
-  resposta_admin: z.string().optional().nullable(),
 });
 
 const SuporteUpdateSchema = SuporteCreateSchema.partial();
@@ -141,7 +140,6 @@ export const createSuporte: RequestHandler = async (req, res) => {
     const input = SuporteCreateSchema.parse(req.body);
 
     const supabase = getSupabaseServiceClient();
-    const { role } = await getUserRoleAndEmail(userId);
 
     const insertData: any = {
       id_usuario: userId,
@@ -152,7 +150,6 @@ export const createSuporte: RequestHandler = async (req, res) => {
       titulo: input.titulo,
       descricao: input.descricao,
       status: input.status || "Aberto",
-      resposta_admin: input.resposta_admin || null,
     };
 
     const { data, error } = await supabase
@@ -162,22 +159,6 @@ export const createSuporte: RequestHandler = async (req, res) => {
       .single();
     if (error) throw error;
 
-    if (role === "user") {
-      const { data: admin } = await supabase
-        .from("usuarios")
-        .select("email")
-        .eq("role", "admin")
-        .order("id", { ascending: true })
-        .limit(1)
-        .maybeSingle();
-      const adminEmail = (admin as any)?.email || null;
-
-      await supabase.from("suportes_eventos").insert({
-        suporte_id: data.id,
-        tipo_evento: "criacao",
-        detalhes: `Novo ticket criado e enviado para ${adminEmail || "admin"}`,
-      });
-    }
 
     res.status(201).json({ success: true, data });
   } catch (error: any) {
@@ -224,20 +205,6 @@ export const updateSuporte: RequestHandler = async (req, res) => {
       .select()
       .single();
     if (error) throw error;
-
-    if (
-      role === "admin" &&
-      typeof input.resposta_admin !== "undefined" &&
-      (input.resposta_admin || "").trim() &&
-      input.resposta_admin !== (existing as any).resposta_admin
-    ) {
-      await supabase.from("suportes_eventos").insert({
-        suporte_id: id,
-        tipo_evento: "resposta_admin",
-        detalhes:
-          "Resposta enviada ao usuário criador do ticket (via formulário)",
-      });
-    }
 
     res.json({ success: true, data });
   } catch (error: any) {
@@ -315,10 +282,13 @@ export const responderSuporte: RequestHandler = async (req, res) => {
     if (exErr || !existing)
       return res.status(404).json({ error: "Registro não encontrado" });
 
-    const update: any = {
-      resposta_admin: resposta,
-      data_resposta_admin: new Date().toISOString(),
-    };
+    // Registrar resposta como histórico
+    await supabase.from("suportes_respostas").insert({
+      suporte_id: id,
+      id_usuario: userId,
+      resposta,
+    });
+    const update: any = {};
     if (status) {
       update.status = status;
       if (status === "Resolvido")
@@ -334,12 +304,6 @@ export const responderSuporte: RequestHandler = async (req, res) => {
       .select()
       .single();
     if (error) throw error;
-
-    await supabase.from("suportes_eventos").insert({
-      suporte_id: id,
-      tipo_evento: "resposta_admin",
-      detalhes: "Resposta enviada ao usuário criador do ticket",
-    });
 
     res.json({ success: true, data });
   } catch (error: any) {
@@ -460,14 +424,6 @@ export const addRespostaSuporte: RequestHandler = async (req, res) => {
       await supabase.from("suportes").update(update).eq("id", id);
     }
 
-    await supabase.from("suportes_eventos").insert({
-      suporte_id: id,
-      tipo_evento: role === "admin" ? "resposta_admin" : "resposta_usuario",
-      detalhes:
-        role === "admin"
-          ? "Resposta enviada ao usuário"
-          : "Resposta enviada ao admin",
-    });
 
     const { data: updated } = await supabase
       .from("suportes")
@@ -519,11 +475,6 @@ export const resolverSuporte: RequestHandler = async (req, res) => {
       .single();
     if (error) throw error;
 
-    await supabase.from("suportes_eventos").insert({
-      suporte_id: id,
-      tipo_evento: "status_resolvido",
-      detalhes: "Ticket marcado como Resolvido",
-    });
 
     res.json({ success: true, data });
   } catch (error) {
@@ -564,11 +515,6 @@ export const fecharSuporte: RequestHandler = async (req, res) => {
       .single();
     if (error) throw error;
 
-    await supabase.from("suportes_eventos").insert({
-      suporte_id: id,
-      tipo_evento: "status_fechado",
-      detalhes: "Ticket marcado como Fechado",
-    });
 
     res.json({ success: true, data });
   } catch (error) {

--- a/shared/suportes.ts
+++ b/shared/suportes.ts
@@ -21,8 +21,6 @@ export interface Suporte {
   titulo: string;
   descricao: string;
   status: SuporteStatus;
-  resposta_admin?: string | null;
-  data_resposta_admin?: string | null;
   data_hora_resolvido?: string | null;
   data_hora_fechado?: string | null;
   data_cadastro: string;
@@ -47,7 +45,6 @@ export interface CreateSuporteRequest {
   titulo: string;
   descricao: string;
   status?: SuporteStatus; // admin may set
-  resposta_admin?: string | null; // admin may set
 }
 
 export interface UpdateSuporteRequest extends Partial<CreateSuporteRequest> {}
@@ -80,7 +77,7 @@ export const SUPORTE_EXPORT_COLUMNS: { key: string; label: string }[] = [
   { key: "nome_usuario", label: "Nome" },
   { key: "email_usuario", label: "Email" },
   { key: "descricao", label: "Descrição" },
-  { key: "resposta_admin", label: "Resposta Admin" },
+  { key: "respostas", label: "Respostas" },
   { key: "data_cadastro", label: "Data de Cadastro" },
   { key: "data_atualizacao", label: "Data de Atualização" },
 ];


### PR DESCRIPTION
## Purpose

Clean up the support module by removing unnecessary admin response fields and the events table. The user requested to:
- Remove `resposta_admin` and `data_resposta_admin` fields from all components
- Delete the `suportes_eventos` table entirely as it's not needed
- Enhance CSV export to include ALL data with a new "Respostas" column showing response history

## Code changes

### Database Schema
- Removed `resposta_admin` and `data_resposta_admin` columns from `suportes` table
- Completely removed `suportes_eventos` table and its indexes

### Frontend Changes
- **SuporteForm.tsx**: Removed `resposta_admin` field from form schema and component state
- **SuportesModule.tsx**: Enhanced CSV export functionality to:
  - Fetch ALL records (not just current page) with pagination
  - Load response history for each support ticket
  - Add "Respostas" column with formatted response data (User - DateTime format)

### Backend Changes
- **suportes.ts**: Removed all `resposta_admin` field handling and `suportes_eventos` table operations
- Updated response handling to use `suportes_respostas` table for history tracking
- Removed event logging for ticket creation, admin responses, and status changes

### Shared Types
- **suportes.ts**: Removed `resposta_admin` and `data_resposta_admin` from interface definitions
- Updated export columns to replace "Resposta Admin" with "Respostas"To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 66`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0cf867d99bac4113b87a12972a488e99/quantum-space)

👀 [Preview Link](https://0cf867d99bac4113b87a12972a488e99-quantum-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0cf867d99bac4113b87a12972a488e99</projectId>-->
<!--<branchName>quantum-space</branchName>-->